### PR TITLE
refactor: remove unused button and image elements in MisFavoritos and…

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -897,12 +897,7 @@ function Dashboard() {
         <section className="recent-courses">
           <div className="section-header">
             <h2>Continuar Aprendiendo</h2>
-            <button 
-              className="see-all-btn"
-              onClick={() => handleNavigation('/catalogo')}
-            >
-              Ver todos
-            </button>
+            
           </div>
           <div className="courses-grid">
             {recentCourses.length === 0 ? (

--- a/src/pages/MisFavoritos.jsx
+++ b/src/pages/MisFavoritos.jsx
@@ -373,24 +373,6 @@ function MisFavoritos() {
             <div className={`cursos-grid ${vistaGrid ? 'grid-view' : 'list-view'}`}>
               {cursosFiltrados.map((curso) => (
                 <div key={curso.id} className="curso-card">
-                  <div className="curso-imagen">
-                    <img
-                      src={curso.imagen || 'https://via.placeholder.com/400x250?text=Curso'}
-                      alt={curso.titulo || 'Curso'}
-                      onError={(e) => {
-                        e.currentTarget.src = 'https://via.placeholder.com/400x250?text=Curso';
-                      }}
-                    />
-                    <div className="curso-overlay">
-                      <button 
-                        className="preview-btn"
-                        onClick={() => irAlCurso(curso.url, curso.id)}
-                      >
-                        Ver Curso
-                      </button>
-                    </div>
-                  </div>
-                  
                   <div className="curso-content">
                     <div className="curso-header">
                       <div className="plataforma-badge">{curso.plataforma || 'LearnIA'}</div>


### PR DESCRIPTION
This pull request makes minor UI adjustments to the dashboard and favorites pages by removing navigation and preview buttons from the course listings. These changes streamline the interface and may be part of a broader redesign or simplification effort.

**Dashboard page UI update:**
* Removed the "Ver todos" button from the "Continuar Aprendiendo" section header in `Dashboard.jsx`.

**Favorites page UI update:**
* Removed the course preview image and "Ver Curso" button from each course card in the grid view of `MisFavoritos.jsx`.